### PR TITLE
Make sure 'all' is always the default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ _OBJ = $(patsubst $(SRCDIR)/%,$(ODIR)/%,$(SRCS:.c=.o))
 OBJ = $(filter-out $(ODIR)/main.o,$(_OBJ))
 
 DEPS2 := $(OBJ:.o=.d)
--include $(DEPS2)
 
 all: ijvm
+
+-include $(DEPS2)
 
 $(ODIR)/%.o: $(SRCDIR)/%.c
 	+@[ -d $(ODIR) ] || mkdir -p $(ODIR)


### PR DESCRIPTION
The -include directive was place before `all`, and that made obj/machine.o the default target.

Before:

$ make
make: `obj/machine.o' is up to date.

After:

$ make
make: Nothing to be done for `all'.